### PR TITLE
Interactive websocket commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ A wrapper around the tornado web server.
 Changlog
 --------
 
+0.7 - TBD
+    * Made transform_progress responsible for name spacing the progress messages
+
 0.6 - 18 September 2019
     * Migrated to `delfick_project <https://delfick-project.readthedocs.io/en/latest/index.html>`_
 

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,11 @@ Changlog
 
 0.7 - TBD
     * Made transform_progress responsible for name spacing the progress messages
+    * Store commands can now be interactive. If you define the execute method as
+      taking in ``messages``, then you can process extra messages sent to that
+      command. You then define what messages it accepts by using the
+      ``store.command`` decorator with the ``parent`` option as the interactive
+      command.
 
 0.6 - 18 September 2019
     * Migrated to `delfick_project <https://delfick-project.readthedocs.io/en/latest/index.html>`_

--- a/docs/docs/handlers.rst
+++ b/docs/docs/handlers.rst
@@ -247,7 +247,7 @@ on your handler. For example:
               for thing in progress:
                   yield {"progress": progress, "kwargs": kwargs}
           else:
-              yield progress
+              yield {"progress": progress}
 
       async def process_message(self, path, body, message_id, message_key, progress_cb):
           # With transform_progress above this will generate no progress reply

--- a/docs/docs/interactive_commands.rst
+++ b/docs/docs/interactive_commands.rst
@@ -63,6 +63,9 @@ can take in multiple requests to the same command. For example:
             self.progress_cb("started")
 
             async for message in messages:
+                # Important to mark the message as received
+                message.no_process()
+
                 self.progress_cb(f"got {message.command.__name__}")
 
     @store.command("command4", parent=Command3)
@@ -76,8 +79,9 @@ the completion of that command.
 
 You can determine if the message is also interactive by accessing the
 ``interactive`` property on the ``message``. And you can access the command
-itself by looking at ``message.command``. You don't need to call
-``message.process`` if you just want to use the options on the commands.
+itself by looking at ``message.command``. If you don't want to run the execute
+method on the command, then run ``message.no_process()`` so that finishing the
+parent command doesn't hang waiting for the message to be resolved.
 
 .. note:: interactive commands and their children are not exposed to the http
     endpoints that can be made from the commander.

--- a/docs/docs/interactive_commands.rst
+++ b/docs/docs/interactive_commands.rst
@@ -1,0 +1,127 @@
+Interactive Commands
+====================
+
+When you use the ``commander`` to create commands, you can make a command that
+can take in multiple requests to the same command. For example:
+
+.. code-block:: python
+
+    @store.command("interactive")
+    class Interactive(store.Command):
+        progress_cb = store.injected("progress_cb")
+
+        max_commands = dictobj.Field(sb.integer_spec, default=10)
+
+        async def execute(self, messages):
+            count = 0
+            interactives = []
+
+            # Good idea to give a progress cb saying we have started
+            # So that clients know they can add more commands
+            self.progres_cb("started")
+
+            async for message in messages:
+                count += 1
+                t = message.process()
+
+                if t.interactive:
+                    interactives.append(t)
+                else:
+                    res = await message.process()
+                    self.progress_cb({
+                        "processed": message.command.__name__,
+                        "result": res
+                    })
+
+                if count >= self.max_commands:
+                    break
+
+            if interactives:
+                for i in interactives:
+                    i.cancel()
+                await asyncio.wait([interactives])
+
+    @store.command("command1", parent=Interactive)
+    class Command1(store.Command):
+        option1 = dictobj.Field(sb.string_spec, wrapper=sb.required)
+
+        async def execute(self):
+            return self.option1
+
+    @store.command("command2", parent=Interactive)
+    class Command2(store.Command):
+        flag = dictobj.Field(sb.boolean, default=False)
+
+        async def execute(self):
+            return self.flag
+
+    @store.command("command3", parent=Interactive)
+    class Command3(store.Command):
+        flag = dictobj.Field(sb.boolean, default=False)
+
+        async def execute(self, messages):
+            self.progress_cb("started")
+
+            async for message in messages:
+                self.progress_cb(f"got {message.command.__name__}")
+
+    @store.command("command4", parent=Command3)
+    class Command4(store.Command):
+        async def execute(self):
+            pass
+
+Interactive commands may themselves have interactive commands as children and
+when you call ``message.process()`` you will get a task back that represents
+the completion of that command.
+
+You can determine if the message is also interactive by accessing the
+``interactive`` property on the ``message``. And you can access the command
+itself by looking at ``message.command``. You don't need to call
+``message.process`` if you just want to use the options on the commands.
+
+.. note:: interactive commands and their children are not exposed to the http
+    endpoints that can be made from the commander.
+
+To use the children commands you supply ``message_id`` as a tuple of all the
+``message_id`` values that led to that command.
+
+So say we started the ``Interactive`` command above with::
+
+    {
+      "path": "/v1",
+      "body": {
+        "command": "interactive",
+        "message_id": "MSG1", 
+        "args": {"max_commands": 5}
+      }
+    }
+
+We can then add a command by saying::
+
+    {
+      "path": "/v1",
+      "body": {
+        "command": "command1",
+        "message_id": ["MSG1", "MSG2"]
+        "args": {"option1": 5}
+      }
+    }
+
+And to go deeper we could do::
+
+    {
+      "path": "/v1",
+      "body": {
+        "command": "command3",
+        "message_id": ["MSG1", "MSG3"]
+        "args": {"option1": 5}
+      }
+    }
+
+    {
+      "path": "/v1",
+      "body": {
+        "command": "command4",
+        "message_id": ["MSG1", "MSG3", "MSG4"]
+      }
+    }

--- a/tests/request_handlers/base/test_websockets.py
+++ b/tests/request_handlers/base/test_websockets.py
@@ -249,10 +249,13 @@ describe "SimpleWebSocketBase":
 
             assert len(server.wsconnections) == 0
             assert info["message_key"] is not None
-            assert called == ["process", (msg, {"done": True}, info["message_key"], None)]
+            assert called == ["process", (msg, None, info["message_key"], None)]
 
             connection.close()
-            assert await server.runner.ws_read(connection) is None
+            assert await server.runner.ws_read(connection) == {
+                "message_id": message_id,
+                "reply": {"done": True},
+            }
 
     async it "calls the message_done with exc_info if an exception is raised in process_message", make_wrapper:
         info = {"message_key": None}

--- a/tests/request_handlers/base/test_websockets.py
+++ b/tests/request_handlers/base/test_websockets.py
@@ -96,7 +96,7 @@ describe "SimpleWebSocketBase":
 
         class Handler(SimpleWebSocketBase):
             def transform_progress(s, body, message, **kwargs):
-                yield {"body": body, "message": message, "kwargs": kwargs}
+                yield {"progress": {"body": body, "message": message, "kwargs": kwargs}}
 
             async def process_message(s, path, body, message_id, message_key, progress_cb):
                 progress_cb("WAT", arg=1, do_log=False, stack_extra=1)
@@ -128,7 +128,7 @@ describe "SimpleWebSocketBase":
             def transform_progress(s, body, message, **kwargs):
                 if message == "ignore":
                     return
-                yield message
+                yield {"progress": message}
 
             async def process_message(s, path, body, message_id, message_key, progress_cb):
                 progress_cb("hello")
@@ -162,7 +162,7 @@ describe "SimpleWebSocketBase":
         class Handler(SimpleWebSocketBase):
             def transform_progress(s, body, message, **kwargs):
                 for m in message:
-                    yield m
+                    yield {"progress": m}
 
             async def process_message(s, path, body, message_id, message_key, progress_cb):
                 progress_cb(["hello", "people"])

--- a/tests/request_handlers/command/test_interactive.py
+++ b/tests/request_handlers/command/test_interactive.py
@@ -1,0 +1,346 @@
+# coding: spec
+
+from whirlwind.request_handlers.base import MessageFromExc
+from whirlwind.request_handlers.command import WSHandler
+from whirlwind.commander import Commander
+from whirlwind.store import Store
+
+from delfick_project.option_merge.formatter import MergedOptionStringFormatter
+from delfick_project.errors import DelfickError
+from delfick_project.norms import dictobj, sb
+from unittest import mock
+import pytest
+import time
+import uuid
+
+
+store = Store(formatter=MergedOptionStringFormatter)
+
+
+@store.command("interactive")
+class Interactive(store.Command):
+    progress_cb = store.injected("progress_cb")
+
+    async def execute(self, messages):
+        self.progress_cb("started")
+        async for message in messages:
+            message.no_process()
+            if isinstance(message.command, Stop):
+                break
+
+
+@store.command("stop", parent=Interactive)
+class Stop(store.Command):
+    pass
+
+
+@store.command("interactive_with_error_receiving")
+class InteractiveWithErrorRecieving(store.Command):
+    progress_cb = store.injected("progress_cb")
+
+    async def execute(self, messages):
+        self.progress_cb("started")
+        async for _, message in messages:
+            message.no_process()
+
+
+@store.command("stop", parent=InteractiveWithErrorRecieving)
+class Stop2(store.Command):
+    pass
+
+
+@store.command("interactive_with_error_after_receive")
+class InteractiveWithErrorAfterReceive(store.Command):
+    progress_cb = store.injected("progress_cb")
+
+    async def execute(self, messages):
+        self.progress_cb("started")
+        async for message in messages:
+            raise DelfickError("NUP", fail=True)
+            message.no_process()
+
+
+@store.command("stop", parent=InteractiveWithErrorAfterReceive)
+class Stop3(store.Command):
+    pass
+
+
+@store.command("interactive_with_error_after_process")
+class InteractiveWithErrorAfterProcess(store.Command):
+    progress_cb = store.injected("progress_cb")
+
+    async def execute(self, messages):
+        self.progress_cb("started")
+        async for message in messages:
+            self.progress_cb(await message.process())
+            raise DelfickError("NUP", fail=True)
+
+
+class Echo(store.Command):
+    wrap = None
+    info = dictobj.Field(sb.dictionary_spec)
+
+    async def execute(self):
+        if "error" in self.info:
+            raise Exception(self.info["error"])
+
+        if self.wrap:
+            return {self.wrap: self.info}
+        else:
+            return self.info
+
+
+@store.command("echo", parent=InteractiveWithErrorAfterProcess)
+class Echo1(Echo):
+    wrap = "done_good"
+
+
+@store.command("interactive_with_sub_interactive")
+class InteractiveWithSubInteractive(store.Command):
+    progress_cb = store.injected("progress_cb")
+
+    async def execute(self, messages):
+        self.progress_cb("started")
+        async for message in messages:
+            res = await message.process()
+            self.progress_cb({message.command.__class__.__name__: res})
+            if res == {"stop": True}:
+                break
+
+
+@store.command("echo", parent=InteractiveWithSubInteractive)
+class Echo2(Echo):
+    pass
+
+
+@store.command("sub_interactive", parent=InteractiveWithSubInteractive)
+class SubInteractive(store.Command):
+    progress_cb = store.injected("progress_cb")
+
+    wrap = dictobj.Field(sb.string_spec, wrapper=sb.required)
+
+    async def execute(self, messages):
+        self.progress_cb("started")
+        async for message in messages:
+            res = await message.process()
+            self.progress_cb({self.wrap: res})
+            if res == {"stop": True, "please": True}:
+                break
+
+
+@store.command("echo", parent=SubInteractive)
+class Echo3(Echo):
+    pass
+
+
+class MessageFromExc(MessageFromExc):
+    def process(self, exc_type, exc, tb):
+        if hasattr(exc, "as_dict"):
+            error = exc.as_dict()
+        else:
+            error = str(exc)
+        return {"error_code": exc.__class__.__name__, "error": error}
+
+
+class WSHandler(WSHandler):
+    def initialize(self, *args, **kwargs):
+        super().initialize(*args, **kwargs)
+        self.message_from_exc = MessageFromExc()
+
+
+@pytest.fixture(scope="module")
+async def runner(server_wrapper):
+    def tornado_routes(server):
+        return [
+            (
+                "/v1/ws",
+                WSHandler,
+                {
+                    "commander": Commander(store, final_future=server.final_future),
+                    "server_time": time.time(),
+                    "wsconnections": server.wsconnections,
+                },
+            ),
+        ]
+
+    async with server_wrapper(store, tornado_routes) as server:
+        yield server.runner
+
+
+describe "Interactive commands":
+
+    async it "it can start and control interactive commands", runner, asserter:
+        async with runner.ws_stream(asserter) as stream:
+            await stream.start("/v1", {"command": "interactive"})
+            message_id = stream.message_id
+            await stream.check_reply({"progress": {"info": "started"}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1", {"command": "stop"}, message_id=[message_id, child_message_id]
+            )
+            await stream.check_reply({"received": True}, message_id=[message_id, child_message_id])
+            await stream.check_reply({"done": True})
+
+    async it "can fail if we fail to read from messages properly", runner, asserter:
+        async with runner.ws_stream(asserter) as stream:
+            await stream.start("/v1", {"command": "interactive_with_error_receiving"})
+            message_id = stream.message_id
+            await stream.check_reply({"progress": {"info": "started"}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1", {"command": "stop"}, message_id=[message_id, child_message_id]
+            )
+
+            error = {"error_code": "TypeError", "error": mock.ANY}
+            await stream.check_reply(error, message_id=[message_id, child_message_id])
+            await stream.check_reply(error)
+
+    async it "can fail if we fail to process a command", runner, asserter:
+        async with runner.ws_stream(asserter) as stream:
+            await stream.start("/v1", {"command": "interactive_with_error_after_receive"})
+            message_id = stream.message_id
+            await stream.check_reply({"progress": {"info": "started"}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1", {"command": "stop"}, message_id=[message_id, child_message_id]
+            )
+
+            error = {"error_code": "DelfickError", "error": {"message": "NUP", "fail": True}}
+            await stream.check_reply(error, message_id=[message_id, child_message_id])
+            await stream.check_reply(error)
+
+    async it "can fail after we process a command", runner, asserter:
+        async with runner.ws_stream(asserter) as stream:
+            await stream.start("/v1", {"command": "interactive_with_error_after_process"})
+            message_id = stream.message_id
+            await stream.check_reply({"progress": {"info": "started"}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"amaze": True}}},
+                message_id=[message_id, child_message_id],
+            )
+
+            await stream.check_reply(
+                {"done_good": {"amaze": True}}, message_id=[message_id, child_message_id]
+            )
+            await stream.check_reply({"progress": {"done_good": {"amaze": True}}})
+
+            error = {"error_code": "DelfickError", "error": {"message": "NUP", "fail": True}}
+            await stream.check_reply(error)
+
+    async it "can have sub interactives", runner, asserter:
+        async with runner.ws_stream(asserter) as stream:
+            await stream.start("/v1", {"command": "interactive_with_sub_interactive"})
+            message_id = stream.message_id
+            await stream.check_reply({"progress": {"info": "started"}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"hello": "there"}}},
+                message_id=[message_id, child_message_id],
+            )
+
+            await stream.check_reply({"hello": "there"}, message_id=[message_id, child_message_id])
+            await stream.check_reply({"progress": {"Echo2": {"hello": "there"}}})
+
+            sub_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "sub_interactive", "args": {"wrap": "sub"}},
+                message_id=[message_id, sub_message_id],
+            )
+            await stream.check_reply(
+                {"progress": {"info": "started"}}, message_id=[message_id, sub_message_id],
+            )
+
+            sub_child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"child1": True}}},
+                message_id=[message_id, sub_message_id, sub_child_message_id],
+            )
+
+            await stream.check_reply(
+                {"child1": True}, message_id=[message_id, sub_message_id, sub_child_message_id],
+            )
+            await stream.check_reply(
+                {"progress": {"sub": {"child1": True}}}, message_id=[message_id, sub_message_id]
+            )
+
+            sub_child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"stop": True}}},
+                message_id=[message_id, sub_message_id, sub_child_message_id],
+            )
+
+            await stream.check_reply(
+                {"stop": True}, message_id=[message_id, sub_message_id, sub_child_message_id],
+            )
+            await stream.check_reply(
+                {"progress": {"sub": {"stop": True}}}, message_id=[message_id, sub_message_id]
+            )
+
+            sub_child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"stop": True, "please": True}}},
+                message_id=[message_id, sub_message_id, sub_child_message_id],
+            )
+
+            await stream.check_reply(
+                {"stop": True, "please": True},
+                message_id=[message_id, sub_message_id, sub_child_message_id],
+            )
+            await stream.check_reply(
+                {"progress": {"sub": {"stop": True, "please": True}}},
+                message_id=[message_id, sub_message_id],
+            )
+            await stream.check_reply({"done": True}, message_id=[message_id, sub_message_id])
+            await stream.check_reply({"progress": {"SubInteractive": None}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"hi": "again"}}},
+                message_id=[message_id, child_message_id],
+            )
+
+            await stream.check_reply({"hi": "again"}, message_id=[message_id, child_message_id])
+            await stream.check_reply({"progress": {"Echo2": {"hi": "again"}}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"stop": True}}},
+                message_id=[message_id, child_message_id],
+            )
+
+            await stream.check_reply({"stop": True}, message_id=[message_id, child_message_id])
+            await stream.check_reply({"progress": {"Echo2": {"stop": True}}})
+            await stream.check_reply({"done": True})
+
+    async it "exceptions from processing a command rise", runner, asserter:
+        async with runner.ws_stream(asserter) as stream:
+            await stream.start("/v1", {"command": "interactive_with_sub_interactive"})
+            message_id = stream.message_id
+            await stream.check_reply({"progress": {"info": "started"}})
+
+            child_message_id = str(uuid.uuid1())
+            await stream.start(
+                "/v1",
+                {"command": "echo", "args": {"info": {"error": "SAD"}}},
+                message_id=[message_id, child_message_id],
+            )
+
+            await stream.check_reply(
+                {"error_code": "Exception", "error": "SAD"},
+                message_id=[message_id, child_message_id],
+            )
+            await stream.check_reply({"error_code": "Exception", "error": "SAD"})

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -4,7 +4,7 @@ from whirlwind.commander import Commander
 from whirlwind import test_helpers as thp
 from whirlwind.store import Store
 
-from delfick_project.option_merge import MergedOptionStringFormatter, BadOptionFormat
+from delfick_project.option_merge import MergedOptionStringFormatter, BadOptionFormat, MergedOptions
 from delfick_project.norms import dictobj, sb, BadSpecValue
 from delfick_project.errors_pytest import assertRaises
 from unittest import mock
@@ -218,3 +218,7 @@ describe "Commander":
 
         assert val == value
         assert thing.other is other
+
+    async it "allows commands to be retrieved from a MergedOptions":
+        options = MergedOptions.using({"command": FieldsRequired}, dont_prefix=[dictobj])
+        assert options["command"] is FieldsRequired

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -124,7 +124,7 @@ describe "Commander":
         with assertRaises(
             BadOptionFormat,
             "Can't find key in options",
-            chain=["<input>.body.args.notexisting"],
+            chain=["body.args.notexisting"],
             key="notexisting",
         ):
             await commander.executor(progress_cb, request_handler).execute(
@@ -156,10 +156,7 @@ describe "Commander":
         commander = Commander(store2)
 
         with assertRaises(
-            BadOptionFormat,
-            "Can't find key in options",
-            chain=["<input>.body.args.option"],
-            key="option",
+            BadOptionFormat, "Can't find key in options", chain=["body.args.option"], key="option",
         ):
             await commander.executor(progress_cb, request_handler).execute(
                 "/v1", {"command": "injected_can_have_format_into", "args": {"option": "asdf"}}

--- a/tests/test_interactive_helpers.py
+++ b/tests/test_interactive_helpers.py
@@ -1,0 +1,125 @@
+# coding: spec
+
+from whirlwind.store import pass_on_result
+
+from delfick_project.errors_pytest import assertRaises
+from unittest import mock
+import asynctest
+import asyncio
+import pytest
+
+describe "pass_on_result":
+
+    @pytest.fixture()
+    def run_pass(self):
+        async def run_pass(fut, side_effect, on_command=True, log_exceptions=False):
+            command = mock.Mock(name="command")
+
+            kwargs = {}
+            if isinstance(side_effect, BaseException):
+                kwargs["side_effect"] = side_effect
+            else:
+                kwargs["return_value"] = side_effect
+
+            execute = asynctest.mock.CoroutineMock(name="task", **kwargs)
+            if on_command:
+                command.execute = execute
+                execute = None
+
+            return await pass_on_result(fut, command, execute, log_exceptions=True)
+
+        return run_pass
+
+    @pytest.fixture()
+    def combinations(self):
+        return [
+            {"on_command": True, "log_exceptions": False},
+            {"on_command": True, "log_exceptions": True},
+            {"on_command": False, "log_exceptions": False},
+            {"on_command": False, "log_exceptions": True},
+        ]
+
+    async it "passes on a cancellation", run_pass, combinations:
+        for combination in combinations:
+            fut = asyncio.Future()
+            with assertRaises(asyncio.CancelledError):
+                await run_pass(fut, asyncio.CancelledError(), **combination)
+            assert fut.cancelled()
+
+    async it "passes on an exception", run_pass, combinations:
+
+        class E(Exception):
+            pass
+
+        for combination in combinations:
+            fut = asyncio.Future()
+            error = E("WAT")
+            with assertRaises(E, "WAT"):
+                await run_pass(fut, error, **combination)
+            assert fut.exception() is error
+
+    async it "passes on a result", run_pass, combinations:
+        result = mock.NonCallableMock(name="result")
+
+        for combination in combinations:
+            fut = asyncio.Future()
+            assert await run_pass(fut, result, **combination) is result
+            assert (await fut) is result
+
+    async it "does nothing to fut if it's already cancelled", run_pass, combinations:
+
+        class E(Exception):
+            pass
+
+        error = E("WAT")
+        result = mock.NonCallableMock(name="result")
+        cancelled_error = asyncio.CancelledError()
+
+        fut = asyncio.Future()
+        fut.cancel()
+
+        for combination in combinations:
+            for side_effect in (error, result, cancelled_error):
+                with assertRaises(asyncio.CancelledError):
+                    await run_pass(fut, side_effect, **combination)
+                assert fut.cancelled()
+
+    async it "does nothing to fut already has an exception", run_pass, combinations:
+
+        class E(Exception):
+            pass
+
+        class E2(Exception):
+            pass
+
+        error = E("WAT")
+        result = mock.NonCallableMock(name="result")
+        cancelled_error = asyncio.CancelledError()
+
+        fut = asyncio.Future()
+        fut_error = E2("HELLO")
+        fut.set_exception(fut_error)
+
+        for combination in combinations:
+            for side_effect in (error, result, cancelled_error):
+                with assertRaises(E2, "HELLO"):
+                    await run_pass(fut, side_effect, **combination)
+                assert fut.exception() is fut_error
+
+    async it "does nothing to fut already has a result", run_pass, combinations:
+
+        class E(Exception):
+            pass
+
+        error = E("WAT")
+        result = mock.NonCallableMock(name="result")
+        cancelled_error = asyncio.CancelledError()
+
+        fut = asyncio.Future()
+        fut_result = mock.NonCallableMock(name="fut_result")
+        fut.set_result(fut_result)
+
+        for combination in combinations:
+            for side_effect in (error, result, cancelled_error):
+                assert (await run_pass(fut, side_effect, **combination)) is fut_result
+                assert (await fut) is fut_result

--- a/tests/test_interactive_helpers.py
+++ b/tests/test_interactive_helpers.py
@@ -163,6 +163,13 @@ describe "ProcessItem":
         assert item.messages is messages
         assert item.interactive
 
+    describe "no process":
+        async it "just sets the fut to received True":
+            fut = asyncio.Future()
+            item = ProcessItem(fut, None, None, None)
+            item.no_process()
+            assert (await fut) == {"received": True}
+
     describe "process":
 
         @pytest.fixture()

--- a/tests/test_interactive_helpers.py
+++ b/tests/test_interactive_helpers.py
@@ -1,6 +1,6 @@
 # coding: spec
 
-from whirlwind.store import pass_on_result
+from whirlwind.store import pass_on_result, ProcessItem
 
 from delfick_project.errors_pytest import assertRaises
 from unittest import mock
@@ -123,3 +123,110 @@ describe "pass_on_result":
             for side_effect in (error, result, cancelled_error):
                 assert (await run_pass(fut, side_effect, **combination)) is fut_result
                 assert (await fut) is fut_result
+
+describe "ProcessItem":
+    it "takes in some things and understands a non interactive Command":
+        fut = asyncio.Future()
+
+        class Command:
+            def execute(self):
+                pass
+
+        command = Command()
+        execute = mock.Mock(name="execute")
+        messages = mock.Mock(name="messages")
+
+        item = ProcessItem(fut, command, execute, messages)
+
+        assert item.fut is fut
+        assert item.execute is execute
+        assert item.command is command
+        assert item.messages is messages
+        assert not item.interactive
+
+    it "takes in some things and understands an interactive Command":
+        fut = asyncio.Future()
+
+        class Command:
+            def execute(self, messages):
+                pass
+
+        command = Command()
+        execute = mock.Mock(name="execute")
+        messages = mock.Mock(name="messages")
+
+        item = ProcessItem(fut, command, execute, messages)
+
+        assert item.fut is fut
+        assert item.execute is execute
+        assert item.command is command
+        assert item.messages is messages
+        assert item.interactive
+
+    describe "process":
+
+        @pytest.fixture()
+        def messages(self):
+            class Messages:
+                def __init__(s):
+                    s.ts = []
+
+            return Messages()
+
+        @pytest.fixture()
+        def item_maker(self, messages):
+            def make_item(fut, side_effect, on_command=True):
+                command = mock.Mock(name="command")
+                execute = asynctest.mock.CoroutineMock(name="execute")
+
+                if isinstance(side_effect, BaseException):
+                    execute.side_effect = side_effect
+                else:
+                    execute.return_value = side_effect
+
+                if on_command:
+                    command.execute = execute
+                    execute = None
+
+                return ProcessItem(fut, command, execute, messages)
+
+            return make_item
+
+        it "fails the future if pass_on_result itself fails", messages, item_maker:
+            error = Exception("STUFF")
+            pass_on_result = mock.Mock(name="pass_on_result", side_effect=error)
+
+            fut = asyncio.Future()
+            with mock.patch("whirlwind.store.pass_on_result", pass_on_result):
+                assert item_maker(fut, None).process() is fut
+
+            assert fut.exception() is error
+            assert messages.ts == []
+
+        async it "returns a task from pass_on_result", messages, item_maker:
+            fut = asyncio.Future()
+            task = item_maker(fut, asyncio.CancelledError()).process()
+            assert messages.ts == [(task, False, True)]
+            with assertRaises(asyncio.CancelledError):
+                await task
+            assert fut.cancelled()
+            messages.ts.clear()
+
+            class E(Exception):
+                pass
+
+            error = E("THINGS")
+            fut = asyncio.Future()
+            task = item_maker(fut, error).process()
+            assert messages.ts == [(task, False, True)]
+            with assertRaises(E, "THINGS"):
+                await task
+            assert fut.exception() is error
+            messages.ts.clear()
+
+            result = mock.Mock(name="result")
+            fut = asyncio.Future()
+            task = item_maker(fut, result).process()
+            assert messages.ts == [(task, False, True)]
+            assert (await task) is result
+            assert (await fut) is result

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,13 @@
 # coding: spec
 
-from whirlwind.store import Store, NoSuchPath, NoSuchParent, NonInteractiveParent, command_spec
+from whirlwind.store import (
+    Store,
+    NoSuchPath,
+    NoSuchParent,
+    NonInteractiveParent,
+    command_spec,
+    create_task,
+)
 
 from delfick_project.option_merge import MergedOptionStringFormatter
 from delfick_project.norms import dictobj, sb, Meta, BadSpecValue
@@ -527,7 +534,7 @@ describe "command_spec":
         grandchild2_message_id = str(uuid.uuid1())
 
         def add_runner(name, coro):
-            task = asyncio.get_event_loop().create_task(coro, name=name)
+            task = create_task(coro, name=name)
             runners.append(task)
             return task
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py36,py37,py38
 
 [testenv]
-commands = ./test.sh {posargs}
+commands = ./test.sh tests
 deps =
   -e.
   -e.[peer,tests]

--- a/whirlwind/commander.py
+++ b/whirlwind/commander.py
@@ -4,6 +4,8 @@ import asyncio
 
 
 class Command(dictobj.Spec):
+    _merged_options_formattable = True
+
     async def execute(self):
         raise NotImplementedError("Base command has no execute implementation")
 

--- a/whirlwind/commander.py
+++ b/whirlwind/commander.py
@@ -85,10 +85,10 @@ class Executor:
             )
 
             meta = Meta(everything, self.commander.meta.path).at("<input>")
-            command = self.commander.store.command_spec.normalise(
+            execute = self.commander.store.command_spec.normalise(
                 meta, {"path": path, "body": body}
             )
 
-            return await command.execute()
+            return await execute()
         finally:
             request_future.cancel()

--- a/whirlwind/commander.py
+++ b/whirlwind/commander.py
@@ -40,7 +40,7 @@ class Executor:
         self.extra_options = extra_options
         self.request_handler = request_handler
 
-    async def execute(self, path, body, extra_options=None):
+    async def execute(self, path, body, extra_options=None, allow_ws_only=False):
         """
         Responsible for creating a command and calling execute on it.
 
@@ -88,7 +88,7 @@ class Executor:
 
             meta = Meta(everything, self.commander.meta.path).at("<input>")
             execute = self.commander.store.command_spec.normalise(
-                meta, {"path": path, "body": body}
+                meta, {"path": path, "body": body, "allow_ws_only": allow_ws_only}
             )
 
             return await execute()

--- a/whirlwind/request_handlers/base.py
+++ b/whirlwind/request_handlers/base.py
@@ -305,6 +305,9 @@ class SimpleWebSocketBase(RequestsMixin, websocket.WebSocketHandler):
         self.hook("websocket_opened")
 
     def reply(self, msg, message_id=None, exc_info=None):
+        if msg is None:
+            msg = {"done": True}
+
         # I bypass tornado converting the dictionary so that non jsonable things can be repr'd
         if hasattr(msg, "as_dict"):
             msg = msg.as_dict()

--- a/whirlwind/request_handlers/base.py
+++ b/whirlwind/request_handlers/base.py
@@ -367,7 +367,7 @@ class SimpleWebSocketBase(RequestsMixin, websocket.WebSocketHandler):
 
                 def progress_cb(progress, **kwargs):
                     for m in self.transform_progress(msg, progress, **kwargs):
-                        self.reply({"progress": m}, message_id=message_id)
+                        self.reply(m, message_id=message_id)
 
                 async with self.async_catcher(info, on_processed):
                     info["result"] = await self.process_message(
@@ -415,13 +415,13 @@ class SimpleWebSocketBase(RequestsMixin, websocket.WebSocketHandler):
         .. code-block:: python
 
             for m in self.transform_progress(<request>, "some message", arg=1):
-                # write ``{"reply": {"progress": m}, "message_id": <message_id>}``
+                # write ``{"reply": m, "message_id": <message_id>}``
 
         where ``<request>`` is the entire message that started this stream.
 
-        By default kwargs are ignored and we just yield ``progress`` once
+        By default kwargs are ignored and we just yield ``{"progress": progress}`` once
         """
-        yield progress
+        yield {"progress": progress}
 
     async def process_message(self, path, body, message_id, message_key, progress_cb):
         """

--- a/whirlwind/request_handlers/base.py
+++ b/whirlwind/request_handlers/base.py
@@ -1,3 +1,5 @@
+from whirlwind.store import create_task
+
 from delfick_project.norms import sb, dictobj, Meta
 from tornado.web import RequestHandler, HTTPError
 from tornado import websocket
@@ -393,7 +395,7 @@ class SimpleWebSocketBase(RequestsMixin, websocket.WebSocketHandler):
                     if exc:
                         log.exception(exc, exc_info=(type(exc), exc, exc.__traceback__))
 
-            t = asyncio.get_event_loop().create_task(doit(), name=f"<process_command: {body}>")
+            t = create_task(doit(), name=f"<process_command: {body}>")
             t.add_done_callback(done)
             self.wsconnections[message_key] = t
 

--- a/whirlwind/request_handlers/command.py
+++ b/whirlwind/request_handlers/command.py
@@ -99,7 +99,7 @@ class WSHandler(SimpleWebSocketBase, ProcessReplyMixin):
 
     def transform_progress(self, body, progress, stack_extra=0, **kwargs):
         maker = self.progress_maker(2 + stack_extra)
-        yield maker(body, progress, **kwargs)
+        yield {"progress": maker(body, progress, **kwargs)}
 
     async def process_message(self, path, body, message_id, message_key, progress_cb):
         try:

--- a/whirlwind/request_handlers/command.py
+++ b/whirlwind/request_handlers/command.py
@@ -106,7 +106,7 @@ class WSHandler(SimpleWebSocketBase, ProcessReplyMixin):
             executor = self.commander.executor(
                 progress_cb, self, message_key=message_key, message_id=message_id
             )
-            return await executor.execute(path, body)
+            return await executor.execute(path, body, allow_ws_only=True)
         except NoSuchPath as error:
             raise Finished(
                 status=404,

--- a/whirlwind/store.py
+++ b/whirlwind/store.py
@@ -113,6 +113,10 @@ class ProcessItem:
 
             return task
 
+    def no_process(self):
+        self.fut.set_result({"received": True})
+        return self.fut
+
 
 class MessageHolder:
     def __init__(self, command, final_future):

--- a/whirlwind/test_helpers.py
+++ b/whirlwind/test_helpers.py
@@ -276,19 +276,22 @@ class WSStream:
                     raise exc
                 raise
 
-    async def start(self, path, body):
-        self.message_id = str(uuid.uuid1())
+    async def start(self, path, body, message_id=None):
+        if message_id is None:
+            self.message_id = message_id = str(uuid.uuid1())
         await self.server.ws_write(
-            self.connection, {"path": path, "body": body, "message_id": self.message_id}
+            self.connection, {"path": path, "body": body, "message_id": message_id}
         )
 
-    async def check_reply(self, reply):
+    async def check_reply(self, reply, message_id=None):
         d, nd = await asyncio.wait([self.server.ws_read(self.connection)], timeout=5)
         if nd:
             assert False, "Timedout waiting for future"
 
         got = await list(d)[0]
-        wanted = {"message_id": self.message_id, "reply": reply}
+        if message_id is None:
+            message_id = self.message_id
+        wanted = {"message_id": message_id, "reply": reply}
         if got != wanted:
             print("got --->")
             print(got)


### PR DESCRIPTION
The commander commands currently support websockets in that you can start a command with a websocket request and then receive 0 or more progress messages before the final reply. However you can't send more messages to that running command before it's finished.

This PR makes it possible to define a command as taking in more commands before it is finished and lets you define what commands are valid for that command.

You then address the sub commands by using a list of message_ids leading from the root parent to each child down to where your command is (interactive commands nest infinitely)

See docs/docs/interactive_commands.rst in the PR for a demonstration on how to use this new feature.